### PR TITLE
Respect the 't' parameter in Youtube player for start time

### DIFF
--- a/src/main/resources/Macros/Video20.xml
+++ b/src/main/resources/Macros/Video20.xml
@@ -543,7 +543,7 @@ require(['jquery', 'dash-webm', 'video-js'], function($, dashwebm, videojs) {
   ## which should be transformed into:
   ## https://youtube.googleapis.com/v/&lt;videoId&gt;
   #set ($url = $xcontext.macro.params.url.replaceAll('^.*?[&amp;?]v=(.*?)(&amp;.*|$)', '//www.youtube.com/embed/$1'))
-  ## if video contains a timestamp in format t=20, replace it with start=20, because embeded player uses 'start' parameter instead of 't'
+  ## if video contains a timestamp in format t=20, replace it with start=20, because the embedded player uses 'start' parameter instead of 't'
   #set ($url = $url.replaceAll('(?&lt;=[\?&amp;])t=(\d+)', 'start=$1'))
 #elseif ($xcontext.macro.params.url.indexOf('youtu.be') != -1)
   ## YouTube URLs have the following format:
@@ -551,7 +551,7 @@ require(['jquery', 'dash-webm', 'video-js'], function($, dashwebm, videojs) {
   ## which should be transformed into:
   ## https://youtube.googleapis.com/v/&lt;videoId&gt;
   #set ($url = $xcontext.macro.params.url.replaceAll('^.*youtu.be/(.*?)(&amp;.*|$)', '//www.youtube.com/embed/$1'))
-  ## if video contains a timestamp in format t=20, replace it with start=20, because embeded player uses 'start' parameter instead of 't'
+  ## if video contains a timestamp in format t=20, replace it with start=20, because the embedded player uses 'start' parameter instead of 't'
   #set ($url = $url.replaceAll('(?&lt;=[\?&amp;])t=(\d+)', 'start=$1'))
 #elseif ($xcontext.macro.params.url.indexOf('google') != -1)
   ## Google Video URLs have the following format:

--- a/src/main/resources/Macros/Video20.xml
+++ b/src/main/resources/Macros/Video20.xml
@@ -543,12 +543,16 @@ require(['jquery', 'dash-webm', 'video-js'], function($, dashwebm, videojs) {
   ## which should be transformed into:
   ## https://youtube.googleapis.com/v/&lt;videoId&gt;
   #set ($url = $xcontext.macro.params.url.replaceAll('^.*?[&amp;?]v=(.*?)(&amp;.*|$)', '//www.youtube.com/embed/$1'))
+  ## if video contains a timestamp in format t=20, replace it with start=20, because embeded player uses 'start' parameter instead of 't'
+  #set ($url = $url.replaceAll('(?&lt;=[\?&amp;])t=(\d+)', 'start=$1'))
 #elseif ($xcontext.macro.params.url.indexOf('youtu.be') != -1)
   ## YouTube URLs have the following format:
   ## http://www.youtube.com/watch?v=&lt;videoId&gt;&amp;otherParams
   ## which should be transformed into:
   ## https://youtube.googleapis.com/v/&lt;videoId&gt;
   #set ($url = $xcontext.macro.params.url.replaceAll('^.*youtu.be/(.*?)(&amp;.*|$)', '//www.youtube.com/embed/$1'))
+  ## if video contains a timestamp in format t=20, replace it with start=20, because embeded player uses 'start' parameter instead of 't'
+  #set ($url = $url.replaceAll('(?&lt;=[\?&amp;])t=(\d+)', 'start=$1'))
 #elseif ($xcontext.macro.params.url.indexOf('google') != -1)
   ## Google Video URLs have the following format:
   ## http://video.google.com/videoplay?docid=&lt;videoId&gt;


### PR DESCRIPTION
As for now, if I open a video on Youtube, when I ask Youtube for a url, it gives me a url in format like https://youtu.be/VIDEO_ID?t=START_TIME
When I enter such url into this macros, it transforms the url in //www.youtube.com/embed/VIDEO_ID?t=START_TIME
However, the embedded youtube player requires parameter 'start' instead of 't' to start video from the given timestamp.
These changes fix it.
